### PR TITLE
Add missing packages to `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-This is a repository for building and running AI-driven chats.  __A chat is simply an interactive workflow ( so the basis of surveys, lessons, quizes, etc).__
-You can use AI models from openAI or via Groq. You will need a key, and some are currenlty free. 
+This is a repository for building and running AI-driven chats.  __A chat is simply an interactive workflow ( so the basis of surveys, lessons, quizzes, etc.).__
+You can use AI models from openAI or via Groq. You will need a key, and some are currently free. 
 
 ## Technical Details 
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "type": "module",
   "dependencies": {
     "body-parser": "^1.20.2",
+    "express": "^4.18.2",
     "groq-sdk": "^0.5.0",
-    "index": "^0.4.0"
+    "index": "^0.4.0",
+    "openai": "^4.76.3"
   },
   "scripts": {
     "start": "node app.js"

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -10,7 +10,7 @@ const groq = new Groq({
 });
 
 
-//When openAI finds user prompts with greeetings, it calls this.
+//When openAI finds user prompts with greetings, it calls this.
 
 function createFunctionsFromOptions(options) {
 


### PR DESCRIPTION
This PR adds the following missing packages to `package.json`:

* `express`
* `openai`

Presumably these packages were either installed globally on the original developer's machine which is why this code worked there, but not on an external machine.

Also, we fix a few spelling errors.

