### PR TITLE
add `dotenv` to project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# example .env file; copy this file to the root of the project directory
+# and provide appropriate values for each key.
+
+OPENAI_API_KEY=
+GROQ_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ package-lock.json
 
 # Personal Notes
 .private
+
+# .env file
+.env

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import fs from 'fs';
+import 'dotenv/config';
 // importing modules for each API example
 import runConversation from "./src/modules/functions.js";
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "dependencies": {
     "body-parser": "^1.20.2",
+    "dotenv": "^16.4.7",
     "express": "^4.18.2",
     "groq-sdk": "^0.5.0",
     "index": "^0.4.0",

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -1,7 +1,7 @@
 import OpenAI from "openai";
-const openai = new OpenAI();
 import {Groq} from 'groq-sdk';
 
+const openai = new OpenAI();
 const groq = new Groq();
 
 

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -1,9 +1,6 @@
 import OpenAI from "openai";
 const openai = new OpenAI();
 import {Groq} from 'groq-sdk';
-//import main from "./chat.js";
-
-//import { config } from 'config.js';
 
 const groq = new Groq();
 

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -5,9 +5,7 @@ import {Groq} from 'groq-sdk';
 
 //import { config } from 'config.js';
 
-const groq = new Groq({
-    apiKey: process.env.GROQ_API_KEY
-});
+const groq = new Groq();
 
 
 //When openAI finds user prompts with greetings, it calls this.


### PR DESCRIPTION
* add `dotenv` as a dependency
* use `dotenv` dependency
* ignore `.env` file (we don't want to check in a file that has our keys in it
* add `.env.example` so developers can see the key names they need (so far)
* remove unused commented out code
* group ai models together in code file
* slight code refactor to reduce code by implicitly using default environment variable name for `groq`'s API key