### PR TITLE
Avoid Undefined Models

### DIFF
--- a/src/modules/bots.js
+++ b/src/modules/bots.js
@@ -1,0 +1,47 @@
+import OpenAI from "openai";
+
+// enum idea came from https://stackoverflow.com/a/53959486
+const BotName = Object.freeze({
+    OPENAI: 'OpenAI',
+    GROQ: 'Groq',
+    // ADD MORE BOTS HERE
+})
+
+const BotAPIKey = Object.freeze({
+    OPENAI: 'OPENAI_API_KEY',
+    GROQ: 'GROQ_API_KEY',
+    // ADD MORE BOT API KEYS HERE
+})
+
+/////////////// Error Map /////////////////
+const errorMap = new Map([
+    [BotName.OPENAI, BotAPIKey.OPENAI],
+    [BotName.GROQ, BotAPIKey.GROQ],
+    // ADD MORE ERROR MESSAGES HERE
+]);
+
+/////////////// FUNCTIONS /////////////////
+function getOpenAIBot() {
+    if(process.env.OPENAI_API_KEY) {
+        return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    } else {
+        return undefined;
+    }
+}
+
+function getGroqBot() {
+    if(process.env.GROQ_API_KEY) {
+        return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    } else {
+        return undefined;
+    }
+}
+
+function getUninsatiatedBotError(botName) {
+    return `${botName} model was not instantiated. Did you supply an ${errorMap.get(botName)}?`;
+}
+
+
+
+export { getOpenAIBot, getGroqBot, getUninsatiatedBotError, BotName };
+

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -123,7 +123,6 @@ async function runConversation(userInput, optionData, model) {
             return response.choices[0].message.tool_calls[0];
         } else {
             console.log("No tool calls found.")
-            return
             // Handle the case where there are no tool calls (e.g., return a default value, throw an error, etc.)
         }
 

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -130,7 +130,8 @@ async function runConversation(userInput, optionData, model) {
        // console.log("->-", response.choices[0].message.tool_calls[0]);
        // return response.choices[0].message.tool_calls[0];
     } catch (e) {
-        console.warn("All tools failed. Using fallback.");
+        const allToolsFailedMessage = "All tools failed. No fallback currently available."
+        console.warn(`${response}\n\n${allToolsFailedMessage}`);
        // return response.choices[0].message.tool_calls[0];
         //return fallback_function(query);
         console.log(e);

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -95,20 +95,28 @@ async function runConversation(userInput, optionData, model) {
     let response;
     try {
         if (model.includes('gpt')) {
-            response = await openai.chat.completions.create({
-                model: model,
-                messages: messages,
-                tools: tools,
-                tool_choice: "auto",
-            });
+            if(openai) {
+                response = await openai.chat.completions.create({
+                    model: model,
+                    messages: messages,
+                    tools: tools,
+                    tool_choice: "auto",
+                });
+            } else {
+                response = getUninsatiatedBotError(BotName.OPENAI)
+            }
         } else {
-            response = await groq.chat.completions.create({
-                messages: messages,
-                model: model,
-                temperature:0.9,
-                tools: tools,
-                tool_choice: "auto"
-            });
+            if (groq) {
+                response = await groq.chat.completions.create({
+                    messages: messages,
+                    model: model,
+                    temperature: 0.9,
+                    tools: tools,
+                    tool_choice: "auto"
+                });
+            } else {
+                response = getUninsatiatedBotError(BotName.GROQ)
+            }
         }
         if (response.choices[0].message.tool_calls && response.choices[0].message.tool_calls.length > 0) {
             console.log("->-", response.choices[0].message.tool_calls[0]);

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -135,6 +135,7 @@ async function runConversation(userInput, optionData, model) {
        // return response.choices[0].message.tool_calls[0];
         //return fallback_function(query);
         console.log(e);
+        return response + "<br /><br />" + allToolsFailedMessage;
     }
 }
 

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -1,8 +1,8 @@
-import OpenAI from "openai";
-import {Groq} from 'groq-sdk';
+import {BotName, getGroqBot, getOpenAIBot, getUninsatiatedBotError} from "./bots.js";
 
-const openai = new OpenAI();
-const groq = new Groq();
+
+const openai = getOpenAIBot();
+const groq = getGroqBot();
 
 
 //When openAI finds user prompts with greetings, it calls this.


### PR DESCRIPTION
This PR changes how the models get instantiated; the code is probably a bit over-engineered.

First, if an API key doesn't exist for a model, we don't try to instantiate the model. Instead, we return `undefined` just as 
Brendan Eich intended.

Of course, that means we have to do a check before we try to use the model, so we have to have code in two places; perhaps there is a refactoring or abstraction opportunity here. On the other hand, that might just devolve into moving code around.